### PR TITLE
feat: add valkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you are seeing images that start with 'bitnami/', it's time to patch !
 - [bitnami/rabbitmq](./helm/bitnami-rabbitmq)
 - [bitnami/redis](./helm/bitnami-redis)
 - [bitnami/thanos](./helm/bitnami-thanos)
+- [bitnami/valkey](./helm/bitnami-valkey)
 - [kyverno/kyverno](./helm/kyverno-kyverno)
 - [vmware-tanzu/velero](./helm/vmware-tanzu-velero)
 

--- a/helm/bitnami-valkey/values.yaml
+++ b/helm/bitnami-valkey/values.yaml
@@ -1,0 +1,27 @@
+global:
+  security:
+    # NOTE: this may be needed depending the version of the chart
+    allowInsecureImages: true
+
+image:
+  repository: bitnamilegacy/valkey
+
+kubectl:
+  image:
+    repository: bitnamilegacy/kubectl
+
+metrics:
+  image:
+    repository: bitnamilegacy/valkey-exporter
+
+sentinel:
+  image:
+    repository: bitnamilegacy/valkey-sentinel
+
+sysctl:
+  image:
+    repository: bitnamilegacy/os-shell
+
+volumePermissions:
+  image:
+    repository: bitnamilegacy/os-shell


### PR DESCRIPTION
# Pull Request Overview

This PR adds support for Valkey by creating a new Helm chart configuration to address Bitnami image deprecation. The addition provides an alternative to Redis using the same bitnamilegacy repositories.

Creates a new helm/bitnami-valkey/values.yaml file with image repository configurations
Updates the README.md to include the new Valkey chart in the supported charts list